### PR TITLE
Add redis storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 `pip install -r requirements.text`
 
+## Requires Redis
+
+[Install Redis](https://redis.io/download)
+
+If you are using a Mac: `brew install redis`
+
+Then `redis-server &` will start it up.
+
 ## Run the app
 
 The bot can be run in text mode for use in your console:

--- a/config.py
+++ b/config.py
@@ -26,3 +26,12 @@ BOT_IDENTITY = {
 BOT_PREFIX_OPTIONAL_ON_CHAT = True
 BOT_ALT_PREFIXES = ('@polly',)
 CHATROOM_PRESENCE = ()
+
+BOT_EXTRA_STORAGE_PLUGINS_DIR = join(dirname(__file__), 'plugins/err-storage-redis') # noqa
+STORAGE = 'Redis'
+STORAGE_CONFIG = {
+    'host': os.getenv('REDIS_HOST', 'localhost'),
+    'port': os.getenv('REDIS_PORT', 6379),
+    'db': os.getenv('REDIS_DB', ''),
+    'password': os.getenv('REDIS_PASSWORD', ''),
+}

--- a/plugins/ping/ping.plug
+++ b/plugins/ping/ping.plug
@@ -1,0 +1,10 @@
+[Core]
+name = Ping
+module = ping
+
+[Documentation]
+description = pong
+
+[Python]
+version = 3
+

--- a/plugins/ping/ping.py
+++ b/plugins/ping/ping.py
@@ -1,0 +1,14 @@
+from errbot import BotPlugin, botcmd
+
+
+class Ping(BotPlugin):
+    """
+    pong
+    """
+
+    @botcmd
+    def ping(self, message, args):
+        """
+        Replies with 'pong'
+        """
+        return 'pong'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 errbot==5.1.3
+jsonpickle==0.9.6
 python-dotenv==0.8.2
+redis==2.10.6
 slackclient==1.1.3


### PR DESCRIPTION
Any data for the bot should now be saved to a Redis store so there should not be a requirement for data to be written directly to the disk/machine that it is running on.

It seems that this bot framework expects an admin user to install plugins directly through the chat interface:

`repos install <plugin-github-url>`

However this means that none of the plugins are in source control and would have to be manually reinstalled if the bot ever had to be rebuilt.

It's not ideal to check in the plugins, especially not doing so as a submodule, but it does mean that we can rebuild everything if needs be from scratch at any time.